### PR TITLE
statdate.py: fix max time interval

### DIFF
--- a/statdate.py
+++ b/statdate.py
@@ -45,7 +45,7 @@ class StatDate:
 
     @staticmethod
     def format_start(start):
-        time_delta_max = 180
+        time_delta_max = 181
         if start is None:
             time_delta = timedelta(days=time_delta_max)
             start = datetime.now() - time_delta


### PR DESCRIPTION
## Describe your changes
fixed max time interval
time_delta_max set to 181

## Issue ticket link
resolves #40 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
